### PR TITLE
Fix/added public route

### DIFF
--- a/nitro.config.ts
+++ b/nitro.config.ts
@@ -7,7 +7,7 @@ export default defineNitroConfig({
     CLOUD_FUNCTION_SECRET: process.env.CLOUD_FUNCTION_SECRET,
     PROXY_URL: process.env.PROXY_URL,
     INTERNAL_SECRET: process.env.INTERNAL_SECRET,
-    gcf:{
+    gcf: {
       queueWorkerUrl: process.env.CLOUD_FUNCTION_QUEUE_URL,
       usernameWorkerUrl: process.env.CLOUD_FUNCTION_USERNAME_URL,
     },

--- a/server/middleware/auth.ts
+++ b/server/middleware/auth.ts
@@ -1,7 +1,12 @@
 import { serverSupabaseUser } from "~/utils/supabase";
+import config from "~~/threadseeker.config";
 
 export default defineEventHandler(async (event) => {
-  if (getRequestURL(event).pathname.startsWith("/api")) {
+  const isPublicRoute = config.publicRoutes.some((route) =>
+    getRequestURL(event).pathname.startsWith(route)
+  );
+
+  if (!isPublicRoute) {
     try {
       const user = await serverSupabaseUser(event);
 

--- a/server/utils/use-redis.ts
+++ b/server/utils/use-redis.ts
@@ -5,7 +5,7 @@ import redisDriver from "unstorage/drivers/redis";
 export const useRedis = (event: H3Event): Storage => {
   // No need to recreate client if exists in request context
 
-  if(!event.context._redis) {
+  if (!event.context._redis) {
     event.context._redis = createStorage({
       driver: redisDriver({
         url: process.env.REDIS_URL,

--- a/server/utils/use-threads.ts
+++ b/server/utils/use-threads.ts
@@ -177,19 +177,20 @@ export function useThreads(event: H3Event) {
     },
     getUserProfile: async (username: string): Promise<null | ThreadsUser> => {
       const config = useRuntimeConfig(event);
-      const response = await $fetch<ThreadsUserFunctionResponse>(config.gcf.usernameWorkerUrl,
+      const response = await $fetch<ThreadsUserFunctionResponse>(
+        config.gcf.usernameWorkerUrl,
         {
           method: "GET",
           headers: {
             "Content-Type": "application/json",
-            "Authorization": `${config.CLOUD_FUNCTION_SECRET}`
+            Authorization: `${config.CLOUD_FUNCTION_SECRET}`,
           },
           params: {
             username,
           },
         }
-      )
-      if(response.data && response.status === "ok") {
+      );
+      if (response.data && response.status === "ok") {
         return response.data;
       }
       return null;

--- a/threadseeker.config.ts
+++ b/threadseeker.config.ts
@@ -1,0 +1,3 @@
+export default {
+  publicRoutes: ["/api/v1/threads/report"],
+};


### PR DESCRIPTION
This branch solves #2 issue by creating `threadseeker.config.ts` to assign public routes that don't require auth.